### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Runroom/docker-images/security/code-scanning/1](https://github.com/Runroom/docker-images/security/code-scanning/1)

The best way to fix the problem is to add a `permissions` block at the top level of the workflow, directly below the workflow `name:` and above `on:`. This block should grant only the minimum necessary permissions. For the provided CI pipeline, unless the workflow pushes commits or interacts with pull request API endpoints, it likely only requires `contents: read` access (reading repository code for building and CI steps). If later jobs require more permissions, they can be set at the job level.

**Implementation steps:**
- Edit `.github/workflows/ci.yaml`.
- Insert a block:
  ```yaml
  permissions:
    contents: read
  ```
  just after the `name:` but before the `on:` section (i.e., between line 1 and line 3).

No other changes, imports, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
